### PR TITLE
Added cache proxy connection object

### DIFF
--- a/examples/client_side_caching_mode.php
+++ b/examples/client_side_caching_mode.php
@@ -12,7 +12,7 @@
 
 require __DIR__ . '/../autoload.php';
 
-if (PHP_SAPI !== 'fpm') {
+if (PHP_SAPI !== 'fpm-fcgi') {
     exit('This example available only in FPM mode.');
 }
 

--- a/examples/client_side_caching_mode.php
+++ b/examples/client_side_caching_mode.php
@@ -35,5 +35,5 @@ var_dump($client->get('foo'));
 // 6. Sleep until TTL expired.
 sleep(3);
 
-// 7. Retrieves update value from Redis storage again.
+// 7. Retrieves updated value from Redis storage again.
 var_dump($client->get('foo'));

--- a/examples/client_side_caching_mode.php
+++ b/examples/client_side_caching_mode.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require __DIR__ . '/../autoload.php';
+
+if (PHP_SAPI !== 'fpm') {
+    exit('This example available only in FPM mode.');
+}
+
+// 1. Create client with enabled cache and ttl 2 seconds.
+$client = new \Predis\Client(['cache' => true, 'cache_config' => ['ttl' => 2]]);
+
+// 2. Set key into Redis storage.
+$client->set('foo', 'bar');
+
+// 3. Retrieves from Redis storage and cache response for 2 seconds.
+var_dump($client->get('foo'));
+
+// 4. Set new value for the same key. Just after this invalidation should happen.
+// If not then we have updated value in Redis storage and old value in cache.
+$client->set('foo', 'baz');
+
+// 5. Retrieves value from cache.
+var_dump($client->get('foo'));
+
+// 6. Sleep until TTL expired.
+sleep(3);
+
+// 7. Retrieves update value from Redis storage again.
+var_dump($client->get('foo'));

--- a/examples/client_side_caching_mode_cluster.php
+++ b/examples/client_side_caching_mode_cluster.php
@@ -14,7 +14,7 @@ use Predis\Client;
 
 require __DIR__ . '/../autoload.php';
 
-if (PHP_SAPI !== 'fpm') {
+if (PHP_SAPI !== 'fpm-fcgi') {
     exit('This example available only in FPM mode.');
 }
 

--- a/examples/client_side_caching_mode_cluster.php
+++ b/examples/client_side_caching_mode_cluster.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Predis\Client;
+
+require __DIR__ . '/../autoload.php';
+
+if (PHP_SAPI !== 'fpm') {
+    exit('This example available only in FPM mode.');
+}
+
+// 1. Create client with enabled cache and ttl 2 seconds.
+$client = new Client(
+    [
+        'tcp://127.0.0.1:6372?read_write_timeout=0',
+        'tcp://127.0.0.1:6373?read_write_timeout=0',
+        'tcp://127.0.0.1:6374?read_write_timeout=0',
+    ], [
+    'cluster' => 'redis',
+    'cache' => 1,
+    'cache_config' => ['ttl' => 2],
+]);
+
+// 2. Set key into Redis storage.
+$client->set('foo', 'bar');
+
+// 3. Retrieves from Redis storage and cache response for 2 seconds.
+var_dump($client->get('foo'));
+
+// 4. Set new value for the same key. Just after this invalidation should happen.
+// If not then we have updated value in Redis storage and old value in cache.
+$client->set('foo', 'baz');
+
+// 5. Retrieves value from cache.
+var_dump($client->get('foo'));
+
+// 6. Sleep until TTL expired.
+sleep(3);
+
+// 7. Retrieves update value from Redis storage again.
+var_dump($client->get('foo'));

--- a/examples/client_side_caching_mode_cluster.php
+++ b/examples/client_side_caching_mode_cluster.php
@@ -46,5 +46,5 @@ var_dump($client->get('foo'));
 // 6. Sleep until TTL expired.
 sleep(3);
 
-// 7. Retrieves update value from Redis storage again.
+// 7. Retrieves updated value from Redis storage again.
 var_dump($client->get('foo'));

--- a/src/Configuration/Cache/CacheConfiguration.php
+++ b/src/Configuration/Cache/CacheConfiguration.php
@@ -50,7 +50,11 @@ class CacheConfiguration
 
     public function __construct(array $configuration = null)
     {
-        $this->mapConfiguration($configuration);
+        $this->setDefaultConfiguration();
+
+        if (null !== $configuration) {
+            $this->mapConfiguration($configuration);
+        }
     }
 
     /**
@@ -62,11 +66,14 @@ class CacheConfiguration
     }
 
     /**
-     * @return Closure
+     * @param  string $commandId
+     * @return bool
      */
-    public function getWhitelistCallback(): Closure
+    public function isWhitelistedCommand(string $commandId): bool
     {
-        return $this->whitelistCallback;
+        $callback = $this->whitelistCallback;
+
+        return $callback($commandId);
     }
 
     /**
@@ -88,12 +95,6 @@ class CacheConfiguration
      */
     private function mapConfiguration(array $configuration = null): void
     {
-        if (null === $configuration) {
-            $this->setDefaultConfiguration();
-
-            return;
-        }
-
         $unexpectedKeys = array_filter(array_keys($configuration), function ($key) {
             return !array_key_exists($key, $this->propertiesMapping);
         });
@@ -107,9 +108,6 @@ class CacheConfiguration
             $property = $this->propertiesMapping[$key];
             $this->$property = (int) $value;
         }
-
-        // TODO: Make it user-defined.
-        $this->whitelistCallback = $this->getDefaultWhitelistCallback();
     }
 
     /**

--- a/src/Configuration/Cache/CacheConfiguration.php
+++ b/src/Configuration/Cache/CacheConfiguration.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Configuration\Cache;
+
+use Closure;
+use UnexpectedValueException;
+
+class CacheConfiguration
+{
+    /**
+     * Maximum records count to store in a cache.
+     *
+     * @var int
+     */
+    private $maxCount;
+
+    /**
+     * Time-to-live in seconds for the record stored in a cache.
+     *
+     * @var int
+     */
+    private $ttl;
+
+    /**
+     * Callback to define if given command response is allowed to be cached.
+     *
+     * @var Closure
+     */
+    private $whitelistCallback;
+
+    /**
+     * Mapping for expected array keys to object properties.
+     *
+     * @var array
+     */
+    private $propertiesMapping = [
+        'max_count' => 'maxCount',
+        'ttl' => 'ttl',
+    ];
+
+    public function __construct(array $configuration = null)
+    {
+        $this->mapConfiguration($configuration);
+    }
+
+    /**
+     * @return int
+     */
+    public function getTTl(): int
+    {
+        return $this->ttl;
+    }
+
+    /**
+     * @return Closure
+     */
+    public function getWhitelistCallback(): Closure
+    {
+        return $this->whitelistCallback;
+    }
+
+    /**
+     * Check if given count exceeds max count threshold.
+     *
+     * @param  int  $count
+     * @return bool
+     */
+    public function isExceedsMaxCount(int $count): bool
+    {
+        return $count > $this->maxCount;
+    }
+
+    /**
+     * Map given configuration to object properties.
+     *
+     * @param  array|null $configuration
+     * @return void
+     */
+    private function mapConfiguration(array $configuration = null): void
+    {
+        if (null === $configuration) {
+            $this->setDefaultConfiguration();
+
+            return;
+        }
+
+        $unexpectedKeys = array_filter(array_keys($configuration), function ($key) {
+            return !array_key_exists($key, $this->propertiesMapping);
+        });
+
+        if (!empty($unexpectedKeys)) {
+            $unexpectedKeysString = implode(', ', $unexpectedKeys);
+            throw new UnexpectedValueException("Invalid cache configuration. Given keys are not expected: {$unexpectedKeysString}");
+        }
+
+        foreach ($configuration as $key => $value) {
+            $property = $this->propertiesMapping[$key];
+            $this->$property = (int) $value;
+        }
+
+        // TODO: Make it user-defined.
+        $this->whitelistCallback = $this->getDefaultWhitelistCallback();
+    }
+
+    /**
+     * @return void
+     */
+    private function setDefaultConfiguration(): void
+    {
+        $this->maxCount = 1000;
+        $this->ttl = 0;
+        $this->whitelistCallback = $this->getDefaultWhitelistCallback();
+    }
+
+    /**
+     * @return Closure
+     */
+    private function getDefaultWhitelistCallback(): Closure
+    {
+        // TODO: Define the list of the default whitelisted commands
+        return static function (string $commandId): bool {
+            return $commandId === 'GET';
+        };
+    }
+}

--- a/src/Configuration/Option/Aggregate.php
+++ b/src/Configuration/Option/Aggregate.php
@@ -13,9 +13,12 @@
 namespace Predis\Configuration\Option;
 
 use InvalidArgumentException;
+use Predis\Cache\ApcuCache;
+use Predis\Configuration\Cache\CacheConfiguration;
 use Predis\Configuration\OptionInterface;
 use Predis\Configuration\OptionsInterface;
 use Predis\Connection\AggregateConnectionInterface;
+use Predis\Connection\Cache\CacheProxyConnection;
 use Predis\Connection\NodeConnectionInterface;
 
 /**
@@ -82,6 +85,10 @@ class Aggregate implements OptionInterface
 
             if ($parameters && $autoaggregate) {
                 static::aggregate($options, $connection, $parameters);
+            }
+
+            if ((bool) $options->cache) {
+                return new CacheProxyConnection($connection, new CacheConfiguration($options->cache_config), new ApcuCache());
             }
 
             return $connection;

--- a/src/Configuration/OptionsInterface.php
+++ b/src/Configuration/OptionsInterface.php
@@ -15,14 +15,16 @@ namespace Predis\Configuration;
 use Predis\Command\Processor\ProcessorInterface;
 
 /**
- * @property callable                            $aggregate   Custom aggregate connection initializer
- * @property callable                            $cluster     Aggregate connection initializer for clustering
- * @property \Predis\Connection\FactoryInterface $connections Connection factory for creating new connections
- * @property bool                                $exceptions  Toggles exceptions in client for -ERR responses
- * @property ProcessorInterface                  $prefix      Key prefixing strategy using the supplied string as prefix
- * @property \Predis\Command\FactoryInterface    $commands    Command factory for creating Redis commands
- * @property callable                            $replication Aggregate connection initializer for replication
- * @property int                                 $readTimeout Timeout in milliseconds between read operations on reading from multiple connections.
+ * @property callable                            $aggregate    Custom aggregate connection initializer
+ * @property bool                                $cache        Whether to use in-memory caching.
+ * @property array                               $cache_config Configuration for in-memory caching.
+ * @property callable                            $cluster      Aggregate connection initializer for clustering
+ * @property \Predis\Connection\FactoryInterface $connections  Connection factory for creating new connections
+ * @property bool                                $exceptions   Toggles exceptions in client for -ERR responses
+ * @property ProcessorInterface                  $prefix       Key prefixing strategy using the supplied string as prefix
+ * @property \Predis\Command\FactoryInterface    $commands     Command factory for creating Redis commands
+ * @property callable                            $replication  Aggregate connection initializer for replication
+ * @property int                                 $readTimeout  Timeout in milliseconds between read operations on reading from multiple connections.
  */
 interface OptionsInterface
 {

--- a/src/Connection/Cache/CacheProxyConnection.php
+++ b/src/Connection/Cache/CacheProxyConnection.php
@@ -130,6 +130,7 @@ class CacheProxyConnection implements ConnectionInterface
      */
     public function getSentinelConnection(): NodeConnectionInterface
     {
+        /* @phpstan-ignore-line */
         return $this->connection->getSentinelConnection();
     }
 

--- a/src/Connection/Cache/CacheProxyConnection.php
+++ b/src/Connection/Cache/CacheProxyConnection.php
@@ -16,6 +16,7 @@ use Predis\Cache\CacheWithMetadataInterface;
 use Predis\Command\CommandInterface;
 use Predis\Configuration\Cache\CacheConfiguration;
 use Predis\Connection\ConnectionInterface;
+use Predis\Connection\NodeConnectionInterface;
 
 class CacheProxyConnection implements ConnectionInterface
 {
@@ -89,11 +90,10 @@ class CacheProxyConnection implements ConnectionInterface
      */
     public function executeCommand(CommandInterface $command)
     {
-        $whitelistCallback = $this->cacheConfiguration->getWhitelistCallback();
         $commandId = $command->getId();
 
         // 1. Check if given command is whitelisted.
-        if (!$whitelistCallback($commandId)) {
+        if (!$this->cacheConfiguration->isWhitelistedCommand($commandId)) {
             return $this->connection->executeCommand($command);
         }
 
@@ -123,6 +123,14 @@ class CacheProxyConnection implements ConnectionInterface
     public function getParameters()
     {
         return $this->connection->getParameters();
+    }
+
+    /**
+     * @return NodeConnectionInterface
+     */
+    public function getSentinelConnection(): NodeConnectionInterface
+    {
+        return $this->connection->getSentinelConnection();
     }
 
     /**

--- a/src/Connection/Cache/CacheProxyConnection.php
+++ b/src/Connection/Cache/CacheProxyConnection.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Connection\Cache;
+
+use Predis\Cache\CacheWithMetadataInterface;
+use Predis\Command\CommandInterface;
+use Predis\Configuration\Cache\CacheConfiguration;
+use Predis\Connection\ConnectionInterface;
+
+class CacheProxyConnection implements ConnectionInterface
+{
+    /**
+     * @var ConnectionInterface
+     */
+    private $connection;
+
+    /**
+     * @var CacheConfiguration
+     */
+    private $cacheConfiguration;
+
+    /**
+     * @var CacheWithMetadataInterface
+     */
+    private $cache;
+
+    public function __construct(
+        ConnectionInterface $connection,
+        CacheConfiguration $cacheConfiguration,
+        CacheWithMetadataInterface $cache
+    ) {
+        $this->connection = $connection;
+        $this->cacheConfiguration = $cacheConfiguration;
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function connect()
+    {
+        $this->connection->connect();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function disconnect()
+    {
+        $this->connection->disconnect();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isConnected()
+    {
+        $this->connection->isConnected();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function writeRequest(CommandInterface $command)
+    {
+        $this->connection->writeRequest($command);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function readResponse(CommandInterface $command)
+    {
+        $this->connection->readResponse($command);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function executeCommand(CommandInterface $command)
+    {
+        $whitelistCallback = $this->cacheConfiguration->getWhitelistCallback();
+        $commandId = $command->getId();
+
+        // 1. Check if given command is whitelisted.
+        if (!$whitelistCallback($commandId)) {
+            return $this->connection->executeCommand($command);
+        }
+
+        // TODO: Enhance CommandInterface to provide a method that returns command key/keys.
+        $key = $command->getArgument(0);
+        $cacheKey = $commandId . '_' . $key;
+        $ttl = $this->cacheConfiguration->getTTl();
+
+        // 2. Returns cached data if key exists in cache.
+        if (false !== $this->cache->exists($cacheKey)) {
+            return $this->cache->read($cacheKey);
+        }
+
+        $response = $this->connection->executeCommand($command);
+
+        // 3. Cache response if it's allowed.
+        if ($this->isAllowedToBeCached()) {
+            $this->cache->add($cacheKey, $response, $ttl);
+        }
+
+        return $response;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getParameters()
+    {
+        return $this->connection->getParameters();
+    }
+
+    /**
+     * @return bool
+     */
+    private function isAllowedToBeCached(): bool
+    {
+        $totalCount = $this->cache->getTotalCount();
+
+        // Check if max count threshold is exceeded.
+        if ($this->cacheConfiguration->isExceedsMaxCount($totalCount + 1)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Connection/Cache/CacheProxyConnection.php
+++ b/src/Connection/Cache/CacheProxyConnection.php
@@ -130,7 +130,7 @@ class CacheProxyConnection implements ConnectionInterface
      */
     public function getSentinelConnection(): NodeConnectionInterface
     {
-        /* @phpstan-ignore-line */
+        /* @phpstan-ignore-next-line */
         return $this->connection->getSentinelConnection();
     }
 

--- a/src/Connection/Cache/CacheProxyConnection.php
+++ b/src/Connection/Cache/CacheProxyConnection.php
@@ -65,7 +65,7 @@ class CacheProxyConnection implements ConnectionInterface
      */
     public function isConnected()
     {
-        $this->connection->isConnected();
+        return $this->connection->isConnected();
     }
 
     /**

--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -13,8 +13,11 @@
 namespace Predis\Connection;
 
 use InvalidArgumentException;
+use Predis\Cache\ApcuCache;
 use Predis\Client;
 use Predis\Command\RawCommand;
+use Predis\Configuration\Cache\CacheConfiguration;
+use Predis\Connection\Cache\CacheProxyConnection;
 use ReflectionClass;
 use UnexpectedValueException;
 
@@ -105,6 +108,10 @@ class Factory implements FactoryInterface
                 'Objects returned by connection initializers must implement ' .
                 "'Predis\Connection\NodeConnectionInterface'."
             );
+        }
+
+        if ((bool) $parameters->cache) {
+            return new CacheProxyConnection($connection, new CacheConfiguration($parameters->cache_config), new ApcuCache());
         }
 
         return $connection;

--- a/src/Connection/Parameters.php
+++ b/src/Connection/Parameters.php
@@ -26,6 +26,7 @@ class Parameters implements ParametersInterface
         'host' => '127.0.0.1',
         'port' => 6379,
         'protocol' => 2,
+        'cache' => false,
     ];
 
     /**

--- a/src/Connection/ParametersInterface.php
+++ b/src/Connection/ParametersInterface.php
@@ -32,7 +32,8 @@ namespace Predis\Connection;
  * @property string $database           Database index (see the SELECT command).
  * @property bool   $async_connect      Performs the connect() operation asynchronously.
  * @property bool   $tcp_nodelay        Toggles the Nagle's algorithm for coalescing.
- * @property bool   $cache              (Relay only) Whether to use in-memory caching.
+ * @property bool   $cache              Whether to use in-memory caching.
+ * @property array  $cache_config       Configuration for in-memory caching.
  * @property string $serializer         (Relay only) Serializer used for data serialization.
  * @property string $compression        (Relay only) Algorithm used for data compression.
  */

--- a/tests/Predis/Configuration/Cache/CacheConfigurationTest.php
+++ b/tests/Predis/Configuration/Cache/CacheConfigurationTest.php
@@ -32,16 +32,12 @@ class CacheConfigurationTest extends PredisTestCase
      * @group disconnected
      * @return void
      */
-    public function testGetWhitelistCallback(): void
+    public function testIsWhitelistedCommand(): void
     {
         $configuration = new CacheConfiguration();
-        $callback = static function ($commandId) {
-            return $commandId === 'GET';
-        };
 
-        $expectedCallback = $configuration->getWhitelistCallback();
-
-        $this->assertSame($expectedCallback('GET'), $callback('GET'));
+        $this->assertTrue($configuration->isWhitelistedCommand('GET'));
+        $this->assertFalse($configuration->isWhitelistedCommand('HGET'));
     }
 
     /**
@@ -63,13 +59,8 @@ class CacheConfigurationTest extends PredisTestCase
     public function testReturnsDefaultConfigurationOnNullConfigurationGiven(): void
     {
         $configuration = new CacheConfiguration();
-        $callback = static function ($commandId) {
-            return $commandId === 'GET';
-        };
 
-        $expectedCallback = $configuration->getWhitelistCallback();
-
-        $this->assertSame($expectedCallback('GET'), $callback('GET'));
+        $this->assertTrue($configuration->isWhitelistedCommand('GET'));
         $this->assertSame(0, $configuration->getTTl());
         $this->assertFalse($configuration->isExceedsMaxCount(1000));
         $this->assertTrue($configuration->isExceedsMaxCount(1001));

--- a/tests/Predis/Configuration/Cache/CacheConfigurationTest.php
+++ b/tests/Predis/Configuration/Cache/CacheConfigurationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Configuration\Cache;
+
+use PredisTestCase;
+use UnexpectedValueException;
+
+class CacheConfigurationTest extends PredisTestCase
+{
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testGetTTl(): void
+    {
+        $configuration = new CacheConfiguration(['ttl' => 100]);
+
+        $this->assertSame(100, $configuration->getTTl());
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testGetWhitelistCallback(): void
+    {
+        $configuration = new CacheConfiguration();
+        $callback = static function ($commandId) {
+            return $commandId === 'GET';
+        };
+
+        $expectedCallback = $configuration->getWhitelistCallback();
+
+        $this->assertSame($expectedCallback('GET'), $callback('GET'));
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testIsExceedsMaxCount(): void
+    {
+        $configuration = new CacheConfiguration(['max_count' => 2]);
+
+        $this->assertFalse($configuration->isExceedsMaxCount(2));
+        $this->assertTrue($configuration->isExceedsMaxCount(3));
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testReturnsDefaultConfigurationOnNullConfigurationGiven(): void
+    {
+        $configuration = new CacheConfiguration();
+        $callback = static function ($commandId) {
+            return $commandId === 'GET';
+        };
+
+        $expectedCallback = $configuration->getWhitelistCallback();
+
+        $this->assertSame($expectedCallback('GET'), $callback('GET'));
+        $this->assertSame(0, $configuration->getTTl());
+        $this->assertFalse($configuration->isExceedsMaxCount(1000));
+        $this->assertTrue($configuration->isExceedsMaxCount(1001));
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testThrowsExceptionOnUnexpectedConfigurationKeyGiven(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid cache configuration. Given keys are not expected: foo');
+
+        new CacheConfiguration(['foo' => 'bar']);
+    }
+}

--- a/tests/Predis/Configuration/Option/AggregateTest.php
+++ b/tests/Predis/Configuration/Option/AggregateTest.php
@@ -66,10 +66,12 @@ class AggregateTest extends PredisTestCase
 
         /** @var MockObject|OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
         $options
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('__get')
-            ->with('connections');
+            ->with('cache')
+            ->willReturn(false);
 
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
         $connection
@@ -100,9 +102,10 @@ class AggregateTest extends PredisTestCase
         /** @var MockObject|OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('__get')
-            ->with('connections');
+            ->with('cache')
+            ->willReturn(false);
 
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
         $connection
@@ -146,10 +149,10 @@ class AggregateTest extends PredisTestCase
         /** @var MockObject|OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('__get')
-            ->with('connections')
-            ->willReturn($factory);
+            ->withConsecutive(['connections'], ['cache'])
+            ->willReturnOnConsecutiveCalls($factory, false);
 
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')
             ->getMock();
@@ -185,9 +188,10 @@ class AggregateTest extends PredisTestCase
         /** @var MockObject|OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('__get')
-            ->with('connections');
+            ->with('cache')
+            ->willReturn(false);
 
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
         $connection

--- a/tests/Predis/Connection/Cache/CacheProxyConnectionTest.php
+++ b/tests/Predis/Connection/Cache/CacheProxyConnectionTest.php
@@ -1,0 +1,418 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Connection\Cache;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Cache\CacheWithMetadataInterface;
+use Predis\Command\CommandInterface;
+use Predis\Configuration\Cache\CacheConfiguration;
+use Predis\Connection\ConnectionInterface;
+use PredisTestCase;
+
+class CacheProxyConnectionTest extends PredisTestCase
+{
+    /**
+     * @var MockObject|ConnectionInterface|MockObject
+     */
+    private $mockConnection;
+
+    /**
+     * @var MockObject|CacheConfiguration|MockObject
+     */
+    private $mockCacheConfiguration;
+
+    /**
+     * @var MockObject|CacheWithMetadataInterface|MockObject
+     */
+    private $mockCacheWithMetadata;
+
+    /**
+     * @var MockObject|CommandInterface|MockObject
+     */
+    private $mockCommand;
+
+    /**
+     * @var CacheProxyConnection
+     */
+    private $proxyConnection;
+
+    protected function setUp(): void
+    {
+        $this->mockConnection = $this->getMockBuilder(ConnectionInterface::class)->getMock();
+        $this->mockCacheConfiguration = $this->getMockBuilder(CacheConfiguration::class)->getMock();
+        $this->mockCacheWithMetadata = $this->getMockBuilder(CacheWithMetadataInterface::class)->getMock();
+        $this->mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+
+        $this->proxyConnection = new CacheProxyConnection(
+            $this->mockConnection,
+            $this->mockCacheConfiguration,
+            $this->mockCacheWithMetadata
+        );
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testConnect(): void
+    {
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('connect')
+            ->withAnyParameters();
+
+        $this->proxyConnection->connect();
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testDisconnect(): void
+    {
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('disconnect')
+            ->withAnyParameters();
+
+        $this->proxyConnection->disconnect();
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testIsConnected(): void
+    {
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('isConnected')
+            ->withAnyParameters();
+
+        $this->proxyConnection->isConnected();
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testWriteRequest(): void
+    {
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('writeRequest')
+            ->with($this->mockCommand);
+
+        $this->proxyConnection->writeRequest($this->mockCommand);
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testReadResponse(): void
+    {
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('readResponse')
+            ->with($this->mockCommand);
+
+        $this->proxyConnection->readResponse($this->mockCommand);
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testGetParameters(): void
+    {
+        $expectedParams = ['param1' => 'value', 'param2' => 'value'];
+
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('getParameters')
+            ->withAnyParameters()
+            ->willReturn($expectedParams);
+
+        $this->assertSame($expectedParams, $this->proxyConnection->getParameters());
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testExecuteCommandExecutesBlacklistedCommandAgainstConnection(): void
+    {
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('getWhitelistCallback')
+            ->withAnyParameters()
+            ->willReturn(static function ($commandId) {
+                return $commandId === 'GET';
+            });
+
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('executeCommand')
+            ->with($this->mockCommand)
+            ->willReturn('OK');
+
+        $this->mockCommand
+            ->expects($this->once())
+            ->method('getId')
+            ->withAnyParameters()
+            ->willReturn('HSET');
+
+        $this->mockCommand
+            ->expects($this->never())
+            ->method('getArgument')
+            ->withAnyParameters();
+
+        $this->mockCacheConfiguration
+            ->expects($this->never())
+            ->method('getTTl')
+            ->withAnyParameters();
+
+        $this->mockCacheConfiguration
+            ->expects($this->never())
+            ->method('isExceedsMaxCount')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('exists')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('read')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('add')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('getTotalCount')
+            ->withAnyParameters();
+
+        $this->assertSame('OK', $this->proxyConnection->executeCommand($this->mockCommand));
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testExecuteCommandExecutesCommandAgainstCacheIfKeyExists(): void
+    {
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('getWhitelistCallback')
+            ->withAnyParameters()
+            ->willReturn(static function ($commandId) {
+                return $commandId === 'GET';
+            });
+
+        $this->mockConnection
+            ->expects($this->never())
+            ->method('executeCommand')
+            ->withAnyParameters();
+
+        $this->mockCommand
+            ->expects($this->once())
+            ->method('getId')
+            ->withAnyParameters()
+            ->willReturn('GET');
+
+        $this->mockCommand
+            ->expects($this->once())
+            ->method('getArgument')
+            ->with(0)
+            ->willReturn('key');
+
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('getTTl')
+            ->withAnyParameters()
+            ->willReturn(100);
+
+        $this->mockCacheConfiguration
+            ->expects($this->never())
+            ->method('isExceedsMaxCount')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->once())
+            ->method('exists')
+            ->with('GET_key')
+            ->willReturn(true);
+
+        $this->mockCacheWithMetadata
+            ->expects($this->once())
+            ->method('read')
+            ->with('GET_key')
+            ->willReturn('value');
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('add')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('getTotalCount')
+            ->withAnyParameters();
+
+        $this->assertSame('value', $this->proxyConnection->executeCommand($this->mockCommand));
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testExecuteCommandAgainstConnectionCacheResponseIfAllowed(): void
+    {
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('getWhitelistCallback')
+            ->withAnyParameters()
+            ->willReturn(static function ($commandId) {
+                return $commandId === 'GET';
+            });
+
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('executeCommand')
+            ->with($this->mockCommand)
+            ->willReturn('value');
+
+        $this->mockCommand
+            ->expects($this->once())
+            ->method('getId')
+            ->withAnyParameters()
+            ->willReturn('GET');
+
+        $this->mockCommand
+            ->expects($this->once())
+            ->method('getArgument')
+            ->with(0)
+            ->willReturn('key');
+
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('getTTl')
+            ->withAnyParameters()
+            ->willReturn(100);
+
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('isExceedsMaxCount')
+            ->with(101)
+            ->willReturn(false);
+
+        $this->mockCacheWithMetadata
+            ->expects($this->once())
+            ->method('exists')
+            ->with('GET_key')
+            ->willReturn(false);
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('read')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->once())
+            ->method('add')
+            ->with('GET_key', 'value', 100);
+
+        $this->mockCacheWithMetadata
+            ->expects($this->once())
+            ->method('getTotalCount')
+            ->withAnyParameters()
+            ->willReturn(100);
+
+        $this->assertSame('value', $this->proxyConnection->executeCommand($this->mockCommand));
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testExecuteCommandAgainstConnectionDoNotCacheResponseIfNotAllowed(): void
+    {
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('getWhitelistCallback')
+            ->withAnyParameters()
+            ->willReturn(static function ($commandId) {
+                return $commandId === 'GET';
+            });
+
+        $this->mockConnection
+            ->expects($this->once())
+            ->method('executeCommand')
+            ->with($this->mockCommand)
+            ->willReturn('value');
+
+        $this->mockCommand
+            ->expects($this->once())
+            ->method('getId')
+            ->withAnyParameters()
+            ->willReturn('GET');
+
+        $this->mockCommand
+            ->expects($this->once())
+            ->method('getArgument')
+            ->with(0)
+            ->willReturn('key');
+
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('getTTl')
+            ->withAnyParameters()
+            ->willReturn(100);
+
+        $this->mockCacheConfiguration
+            ->expects($this->once())
+            ->method('isExceedsMaxCount')
+            ->with(101)
+            ->willReturn(true);
+
+        $this->mockCacheWithMetadata
+            ->expects($this->once())
+            ->method('exists')
+            ->with('GET_key')
+            ->willReturn(false);
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('read')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->never())
+            ->method('add')
+            ->withAnyParameters();
+
+        $this->mockCacheWithMetadata
+            ->expects($this->once())
+            ->method('getTotalCount')
+            ->withAnyParameters()
+            ->willReturn(100);
+
+        $this->assertSame('value', $this->proxyConnection->executeCommand($this->mockCommand));
+    }
+}

--- a/tests/Predis/Connection/Cache/CacheProxyConnectionTest.php
+++ b/tests/Predis/Connection/Cache/CacheProxyConnectionTest.php
@@ -97,9 +97,10 @@ class CacheProxyConnectionTest extends PredisTestCase
         $this->mockConnection
             ->expects($this->once())
             ->method('isConnected')
-            ->withAnyParameters();
+            ->withAnyParameters()
+            ->willReturn(true);
 
-        $this->proxyConnection->isConnected();
+        $this->assertTrue($this->proxyConnection->isConnected());
     }
 
     /**

--- a/tests/Predis/Connection/FactoryTest.php
+++ b/tests/Predis/Connection/FactoryTest.php
@@ -14,6 +14,7 @@ namespace Predis\Connection;
 
 use Predis\Client;
 use Predis\Command\RawCommand;
+use Predis\Connection\Cache\CacheProxyConnection;
 use PredisTestCase;
 use ReflectionObject;
 use stdClass;
@@ -593,6 +594,20 @@ class FactoryTest extends PredisTestCase
 
         $this->assertInstanceOf(RawCommand::class, $initCommands[0]);
         $this->assertSame('HELLO', $initCommands[2]->getId());
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testCreatesCacheProxyConnection(): void
+    {
+        $parameters = ['cache' => true];
+
+        $factory = new Factory();
+        $connection = $factory->create($parameters);
+
+        $this->assertInstanceOf(CacheProxyConnection::class, $connection);
     }
 
     // ******************************************************************** //

--- a/tests/Predis/Connection/ParametersTest.php
+++ b/tests/Predis/Connection/ParametersTest.php
@@ -27,6 +27,7 @@ class ParametersTest extends PredisTestCase
         $this->assertEquals($defaults['scheme'], $parameters->scheme);
         $this->assertEquals($defaults['host'], $parameters->host);
         $this->assertEquals($defaults['port'], $parameters->port);
+        $this->assertFalse($parameters->cache);
     }
 
     /**
@@ -419,6 +420,7 @@ class ParametersTest extends PredisTestCase
             'host' => '127.0.0.1',
             'port' => 6379,
             'protocol' => 2,
+            'cache' => false,
         ];
     }
 


### PR DESCRIPTION
Closes #1378
Closes #1388
Closes #1390
Closes #1391

Basic implementation of Cache proxy connection, some configuration are still didn't specified. Will be added in next PR, for now is just a basic approach to read and write into/from cache.