### PR TITLE
Fixed bug with multiple invalidations and null invalidation payload

### DIFF
--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -1386,9 +1386,9 @@ class ClientTest extends PredisTestCase
      */
     public function testClientInvalidateCacheOnInvalidateResponseWithRedisUrlGiven(): void
     {
-        $url = "redis://" . constant('REDIS_SERVER_HOST') .
-            ":" . constant('REDIS_SERVER_PORT') . "?database=" . constant('REDIS_SERVER_DBNUM') .
-            "&cache=true&protocol=3";
+        $url = 'redis://' . constant('REDIS_SERVER_HOST') .
+            ':' . constant('REDIS_SERVER_PORT') . '?database=' . constant('REDIS_SERVER_DBNUM') .
+            '&cache=true&protocol=3';
 
         $client = new Client($url);
 


### PR DESCRIPTION
1. Updated command retry script in case if multiple invalidation will be received.
2. Updated on push notification callback, to flush cache on NULL invalidation payload (it means that FLUSHDB or FLUSHALL command was executed).