### PR TITLE
Make CacheObject available only on cache enabled

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -655,7 +655,7 @@ class Client implements ClientInterface, IteratorAggregate
         }
 
         if (!extension_loaded('apcu')) {
-            return;
+            throw new NotSupportedException('APCu extension is not installed.');
         }
 
         if ($this->connection instanceof RelayConnection) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -654,6 +654,10 @@ class Client implements ClientInterface, IteratorAggregate
             return;
         }
 
+        if (!extension_loaded('apcu')) {
+            return;
+        }
+
         if ($this->connection instanceof RelayConnection) {
             return;
         }

--- a/tests/Predis/Monitor/ConsumerTest.php
+++ b/tests/Predis/Monitor/ConsumerTest.php
@@ -94,7 +94,7 @@ class ConsumerTest extends PredisTestCase
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -120,7 +120,7 @@ class ConsumerTest extends PredisTestCase
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -152,7 +152,7 @@ class ConsumerTest extends PredisTestCase
             ->willReturn($message);
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -182,7 +182,7 @@ class ConsumerTest extends PredisTestCase
             ->willReturn($message);
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 

--- a/tests/Predis/Pipeline/AtomicTest.php
+++ b/tests/Predis/Pipeline/AtomicTest.php
@@ -57,7 +57,7 @@ class AtomicTest extends PredisTestCase
             );
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -248,7 +248,7 @@ class AtomicTest extends PredisTestCase
             );
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 

--- a/tests/Predis/Pipeline/PipelineTest.php
+++ b/tests/Predis/Pipeline/PipelineTest.php
@@ -89,7 +89,7 @@ class PipelineTest extends PredisTestCase
             ->willReturn($object);
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -117,7 +117,7 @@ class PipelineTest extends PredisTestCase
             ->willReturn($error);
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -143,7 +143,7 @@ class PipelineTest extends PredisTestCase
             ->willReturn($error);
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -225,7 +225,7 @@ class PipelineTest extends PredisTestCase
             ->willReturnCallback($this->getReadCallback());
 
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -271,7 +271,7 @@ class PipelineTest extends PredisTestCase
             ->willReturnCallback($this->getReadCallback());
 
         $connection
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -305,7 +305,7 @@ class PipelineTest extends PredisTestCase
             ->method('readResponse')
             ->willReturn($pong);
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 
@@ -375,7 +375,7 @@ class PipelineTest extends PredisTestCase
             ->method('readResponse')
             ->willReturnCallback($this->getReadCallback());
         $connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn(new Parameters(['protocol' => 2]));
 


### PR DESCRIPTION
The goal of this PR is to make cache object accessible only if user enabled cache. The reason behind that is APCu extension that should be installed if cache is enabled, this way we didn't force users that do not use cache install APCu extension