### PR TITLE
Added pending invalidations processor

### DIFF
--- a/examples/client_side_caching_mode.php
+++ b/examples/client_side_caching_mode.php
@@ -12,9 +12,9 @@
 
 require __DIR__ . '/../autoload.php';
 
-if (PHP_SAPI !== 'fpm-fcgi') {
-    exit('This example available only in FPM mode.');
-}
+//if (PHP_SAPI !== 'fpm-fcgi') {
+//    exit('This example available only in FPM mode.');
+//}
 
 // 1. Create client with enabled cache and RESP3 connection mode.
 $client = new Predis\Client(['protocol' => 3, 'cache' => true]);
@@ -32,9 +32,6 @@ echo nl2br('Value in cache: ' . apcu_fetch('GET_foo') . "\n");
 // 5. Set new value for the same key.
 $client->set('foo', 'baz');
 
-// 6. Send any other read command, so invalidation message will be received.
-$client->get('baz');
-
-// 7. Retrieves updated value from Redis storage again.
+// 6. Retrieves updated value from Redis storage again.
 echo nl2br('New value in Redis: ' . $client->get('foo') . "\n");
 echo nl2br('New value in cache: ' . apcu_fetch('GET_foo') . "\n");

--- a/examples/client_side_caching_mode.php
+++ b/examples/client_side_caching_mode.php
@@ -12,9 +12,9 @@
 
 require __DIR__ . '/../autoload.php';
 
-//if (PHP_SAPI !== 'fpm-fcgi') {
-//    exit('This example available only in FPM mode.');
-//}
+if (PHP_SAPI !== 'fpm-fcgi') {
+    exit('This example available only in FPM mode.');
+}
 
 // 1. Create client with enabled cache and RESP3 connection mode.
 $client = new Predis\Client(['protocol' => 3, 'cache' => true]);

--- a/examples/client_side_caching_mode_cluster.php
+++ b/examples/client_side_caching_mode_cluster.php
@@ -43,9 +43,6 @@ echo nl2br('Value in cache: ' . apcu_fetch('GET_foo') . "\n");
 // 5. Set new value for the same key.
 $client->set('foo', 'baz');
 
-// 6. Send any other read command, so invalidation message will be received.
-$client->get('baz');
-
-// 7. Retrieves updated value from Redis storage again.
+// 6. Retrieves updated value from Redis storage again.
 echo nl2br('New value in Redis: ' . $client->get('foo') . "\n");
 echo nl2br('New value in cache: ' . apcu_fetch('GET_foo') . "\n");

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -33,7 +33,7 @@ parameters:
       count: 1
       path: src/Connection/Cluster/PredisCluster.php
     - message: "#^Variable \\$response might not be defined\\.$#"
-      count: 2
+      count: 1
       path: src/Connection/Cluster/RedisCluster.php
     - message: "#^Access to an undefined property Predis\\\\Connection\\\\ParametersInterface\\:\\:\\$role\\.$#"
       count: 1
@@ -45,9 +45,3 @@ parameters:
     - message: "#^Variable \\$connection might not be defined\\.$#"
       count: 1
       path: src/Connection/Replication/MasterSlaveReplication.php
-    - message: "#^Variable \\$response might not be defined\\.$#"
-      count: 1
-      path: src/Connection/Replication/MasterSlaveReplication.php
-    - message: "#^Variable \\$response might not be defined\\.$#"
-      count: 1
-      path: src/Connection/Replication/SentinelReplication.php

--- a/src/Configuration/Option/Cluster.php
+++ b/src/Configuration/Option/Cluster.php
@@ -92,7 +92,7 @@ class Cluster extends Aggregate
         return static function ($parameters, $options, $option) {
             $optionsParameters = $options->parameters ?? [];
 
-            return new PredisCluster(new Parameters($optionsParameters));
+            return new PredisCluster(new Parameters($optionsParameters), null, $options->readTimeout);
         };
     }
 

--- a/src/Configuration/Option/Replication.php
+++ b/src/Configuration/Option/Replication.php
@@ -69,7 +69,7 @@ class Replication extends Aggregate
             case 'sentinel':
             case 'redis-sentinel':
                 return function ($parameters, $options) {
-                    return new SentinelReplication($options->service, $parameters, $options->connections);
+                    return new SentinelReplication($options->service, $parameters, $options->connections, null, $options->readTimeout);
                 };
 
             case 'predis':
@@ -92,7 +92,7 @@ class Replication extends Aggregate
     protected function getDefaultConnectionInitializer()
     {
         return function ($parameters, $options) {
-            $connection = new MasterSlaveReplication();
+            $connection = new MasterSlaveReplication(null, $options->readTimeout);
 
             if ($options->autodiscovery) {
                 $connection->setConnectionFactory($options->connections);

--- a/src/Configuration/OptionsInterface.php
+++ b/src/Configuration/OptionsInterface.php
@@ -26,7 +26,7 @@ use Predis\Command\Processor\ProcessorInterface;
  * @property int                                 $protocol       Version of RESP protocol.
  * @property \Predis\Command\FactoryInterface    $commands       Command factory for creating Redis commands
  * @property callable                            $replication    Aggregate connection initializer for replication
- * @property int                                 $readTimeout    Timeout in milliseconds between read operations on reading from multiple connections.
+ * @property int                                 $readTimeout    Timeout in microseconds between read operations on reading from multiple connections.
  */
 interface OptionsInterface
 {

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -539,7 +539,7 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
      * have to agree that something changed in the configuration of the cluster.
      *
      * @param CommandInterface $command Command instance.
-     * @param string $method Actual method.
+     * @param string           $method  Actual method.
      *
      * @return mixed
      * @throws Throwable

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -736,4 +736,18 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
             usleep($this->readTimeout);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDataToRead(): bool
+    {
+        foreach ($this->pool as $connection) {
+            if ($connection->hasDataToRead()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -69,4 +69,18 @@ interface ConnectionInterface
      * @return ParametersInterface
      */
     public function getParameters();
+
+    /**
+     * Checks if current connection has data to read from server.
+     *
+     * @return bool
+     */
+    public function hasDataToRead(): bool;
+
+    /**
+     * Reads a response from the server.
+     *
+     * @return mixed
+     */
+    public function read();
 }

--- a/src/Connection/NodeConnectionInterface.php
+++ b/src/Connection/NodeConnectionInterface.php
@@ -47,18 +47,4 @@ interface NodeConnectionInterface extends ConnectionInterface
      * @param CommandInterface $command Instance of a Redis command.
      */
     public function addConnectCommand(CommandInterface $command);
-
-    /**
-     * Reads a response from the server.
-     *
-     * @return mixed
-     */
-    public function read();
-
-    /**
-     * Checks if current connection has data to read from server.
-     *
-     * @return bool
-     */
-    public function hasDataToRead(): bool;
 }

--- a/src/Connection/Replication/MasterSlaveReplication.php
+++ b/src/Connection/Replication/MasterSlaveReplication.php
@@ -486,7 +486,7 @@ class MasterSlaveReplication implements ReplicationInterface
      * Retries the execution of a command upon slave failure.
      *
      * @param CommandInterface $command Command instance.
-     * @param string $method Actual method.
+     * @param string           $method  Actual method.
      *
      * @return mixed
      * @throws Throwable

--- a/src/Connection/Replication/MasterSlaveReplication.php
+++ b/src/Connection/Replication/MasterSlaveReplication.php
@@ -20,9 +20,11 @@ use Predis\Connection\ConnectionException;
 use Predis\Connection\FactoryInterface;
 use Predis\Connection\NodeConnectionInterface;
 use Predis\Connection\ParametersInterface;
+use Predis\Connection\Traits\Retry;
 use Predis\Replication\MissingMasterException;
 use Predis\Replication\ReplicationStrategy;
 use Predis\Response\ErrorInterface as ResponseErrorInterface;
+use Throwable;
 
 /**
  * Aggregate connection handling replication of Redis nodes configured in a
@@ -30,6 +32,8 @@ use Predis\Response\ErrorInterface as ResponseErrorInterface;
  */
 class MasterSlaveReplication implements ReplicationInterface
 {
+    use Retry;
+
     /**
      * @var ReplicationStrategy
      */
@@ -71,6 +75,8 @@ class MasterSlaveReplication implements ReplicationInterface
     protected $connectionFactory;
 
     /**
+     * @see OptionsInterface::$readTimeout
+     *
      * @var int
      */
     private $readTimeout = 1000;
@@ -480,53 +486,60 @@ class MasterSlaveReplication implements ReplicationInterface
      * Retries the execution of a command upon slave failure.
      *
      * @param CommandInterface $command Command instance.
-     * @param string           $method  Actual method.
+     * @param string $method Actual method.
      *
      * @return mixed
+     * @throws Throwable
      */
     private function retryCommandOnFailure(CommandInterface $command, $method)
     {
-        while (true) {
-            try {
-                $connection = $this->getConnectionByCommand($command);
-                $response = $connection->$method($command);
+        $callback = function () use ($command, $method) {
+            $connection = $this->getConnectionByCommand($command);
+            $response = $connection->$method($command);
 
-                if ($response instanceof ResponseErrorInterface && $response->getErrorType() === 'LOADING') {
-                    throw new ConnectionException($connection, "Redis is loading the dataset in memory [$connection]");
-                }
+            if ($response instanceof ResponseErrorInterface && $response->getErrorType() === 'LOADING') {
+                throw new ConnectionException($connection, "Redis is loading the dataset in memory [$connection]");
+            }
 
-                break;
-            } catch (ConnectionException $exception) {
-                $connection = $exception->getConnection();
+            return $response;
+        };
+
+        $onCatchCallback = function (Throwable $e) {
+            if ($e instanceof ConnectionException) {
+                $connection = $e->getConnection();
                 $connection->disconnect();
 
                 if ($connection === $this->master && !$this->autoDiscovery) {
                     // Throw immediately when master connection is failing, even
                     // when the command represents a read-only operation, unless
                     // automatic discovery has been enabled.
-                    throw $exception;
-                } else {
-                    // Otherwise remove the failing slave and attempt to execute
-                    // the command again on one of the remaining slaves...
-                    $this->remove($connection);
+                    throw $e;
                 }
+
+                // Otherwise remove the failing slave and attempt to execute
+                // the command again on one of the remaining slaves...
+                $this->remove($connection);
 
                 // ... that is, unless we have no more connections to use.
                 if (!$this->slaves && !$this->master) {
-                    throw $exception;
-                } elseif ($this->autoDiscovery) {
+                    throw $e;
+                }
+
+                if ($this->autoDiscovery) {
                     $this->discover();
                 }
-            } catch (MissingMasterException $exception) {
+            }
+
+            if ($e instanceof MissingMasterException) {
                 if ($this->autoDiscovery) {
                     $this->discover();
                 } else {
-                    throw $exception;
+                    throw $e;
                 }
             }
-        }
+        };
 
-        return $response;
+        return $this->retryOnError($callback, $onCatchCallback, 3, $this->readTimeout, 1);
     }
 
     /**
@@ -586,15 +599,15 @@ class MasterSlaveReplication implements ReplicationInterface
      */
     public function read()
     {
-        while (true) {
+        return $this->retryOnFalse(function () {
             foreach ($this->pool as $connection) {
                 if ($connection->hasDataToRead()) {
                     return $connection->read();
                 }
             }
 
-            usleep($this->readTimeout);
-        }
+            return false;
+        }, 3, $this->readTimeout);
     }
 
     /**

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -715,7 +715,7 @@ class SentinelReplication implements ReplicationInterface
      * configuration to one of the sentinels.
      *
      * @param CommandInterface $command Command instance.
-     * @param string $method Actual method.
+     * @param string           $method  Actual method.
      *
      * @return mixed
      * @throws Throwable

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -16,16 +16,19 @@ use InvalidArgumentException;
 use Predis\Command\CommandInterface;
 use Predis\Command\RawCommand;
 use Predis\CommunicationException;
+use Predis\Configuration\OptionsInterface;
 use Predis\Connection\ConnectionException;
 use Predis\Connection\FactoryInterface as ConnectionFactoryInterface;
 use Predis\Connection\NodeConnectionInterface;
 use Predis\Connection\Parameters;
 use Predis\Connection\ParametersInterface;
+use Predis\Connection\Traits\Retry;
 use Predis\Replication\ReplicationStrategy;
 use Predis\Replication\RoleException;
 use Predis\Response\Error;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ServerException;
+use Throwable;
 
 /**
  * @author Daniele Alessandri <suppakilla@gmail.com>
@@ -33,6 +36,8 @@ use Predis\Response\ServerException;
  */
 class SentinelReplication implements ReplicationInterface
 {
+    use Retry;
+
     /**
      * @var NodeConnectionInterface
      */
@@ -115,6 +120,8 @@ class SentinelReplication implements ReplicationInterface
     protected $updateSentinels = false;
 
     /**
+     * @see OptionsInterface::$readTimeout
+     *
      * @var int
      */
     private $readTimeout = 1000;
@@ -708,33 +715,25 @@ class SentinelReplication implements ReplicationInterface
      * configuration to one of the sentinels.
      *
      * @param CommandInterface $command Command instance.
-     * @param string           $method  Actual method.
+     * @param string $method Actual method.
      *
      * @return mixed
+     * @throws Throwable
      */
     private function retryCommandOnFailure(CommandInterface $command, $method)
     {
-        $retries = 0;
+        $callback = function () use ($command, $method) {
+            return $this->getConnectionByCommand($command)->$method($command);
+        };
 
-        while ($retries <= $this->retryLimit) {
-            try {
-                $response = $this->getConnectionByCommand($command)->$method($command);
-                break;
-            } catch (CommunicationException $exception) {
+        $onCatchCallback = function (Throwable $e) {
+            if ($e instanceof CommunicationException) {
                 $this->wipeServerList();
-                $exception->getConnection()->disconnect();
-
-                if ($retries === $this->retryLimit) {
-                    throw $exception;
-                }
-
-                usleep($this->retryWait * 1000);
-
-                ++$retries;
+                $e->getConnection()->disconnect();
             }
-        }
+        };
 
-        return $response;
+        return $this->retryOnError($callback, $onCatchCallback, $this->retryLimit, $this->retryWait * 1000, 1);
     }
 
     /**
@@ -808,15 +807,15 @@ class SentinelReplication implements ReplicationInterface
      */
     public function read()
     {
-        while (true) {
+        return $this->retryOnFalse(function () {
             foreach ($this->pool as $connection) {
                 if ($connection->hasDataToRead()) {
                     return $connection->read();
                 }
             }
 
-            usleep($this->readTimeout);
-        }
+            return false;
+        }, 3, $this->readTimeout);
     }
 
     /**

--- a/src/Connection/Traits/Retry.php
+++ b/src/Connection/Traits/Retry.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Predis\Connection\Traits;
 
 use Throwable;
@@ -9,17 +19,17 @@ trait Retry
     /**
      * Retries given callback on error using exponential backoff.
      *
-     * @param callable $callback                 Callback to retry
-     * @param callable|null $onCatchCallback     Callback that will be executed in catch before retry.
-     * @param int $maxRetries                    Max retries count
-     * @param int $timeout                       Retry interval in milliseconds
-     * @param int $exponent                      Exponential multiplier
+     * @param  callable      $callback        Callback to retry
+     * @param  callable|null $onCatchCallback Callback that will be executed in catch before retry.
+     * @param  int           $maxRetries      Max retries count
+     * @param  int           $timeout         Retry interval in milliseconds
+     * @param  int           $exponent        Exponential multiplier
      * @return mixed
      * @throws Throwable
      */
     public function retryOnError(
         callable $callback,
-        callable $onCatchCallback = null,
+        ?callable $onCatchCallback = null,
         int $maxRetries = 3,
         int $timeout = 1000,
         int $exponent = 2
@@ -50,10 +60,10 @@ trait Retry
     /**
      * Retries given callback on false response using exponential backoff.
      *
-     * @param callable $callback  Callback to retry
-     * @param int $maxRetries     Max retries count
-     * @param int $timeout        Retry interval in milliseconds
-     * @param int $exponent       Exponential multiplier
+     * @param  callable $callback   Callback to retry
+     * @param  int      $maxRetries Max retries count
+     * @param  int      $timeout    Retry interval in milliseconds
+     * @param  int      $exponent   Exponential multiplier
      * @return mixed
      */
     public function retryOnFalse(

--- a/src/Connection/Traits/Retry.php
+++ b/src/Connection/Traits/Retry.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Predis\Connection\Traits;
+
+use Throwable;
+
+trait Retry
+{
+    /**
+     * Retries given callback on error using exponential backoff.
+     *
+     * @param callable $callback                 Callback to retry
+     * @param callable|null $onCatchCallback     Callback that will be executed in catch before retry.
+     * @param int $maxRetries                    Max retries count
+     * @param int $timeout                       Retry interval in milliseconds
+     * @param int $exponent                      Exponential multiplier
+     * @return mixed
+     * @throws Throwable
+     */
+    public function retryOnError(
+        callable $callback,
+        callable $onCatchCallback = null,
+        int $maxRetries = 3,
+        int $timeout = 1000,
+        int $exponent = 2
+    ) {
+        try {
+            return $callback();
+        } catch (Throwable $e) {
+            if (is_callable($onCatchCallback)) {
+                $onCatchCallback($e);
+            }
+
+            if ($maxRetries > 0) {
+                usleep($timeout);
+
+                return $this->retryOnError(
+                    $callback,
+                    $onCatchCallback,
+                    $maxRetries - 1,
+                    $timeout * $exponent,
+                    $exponent
+                );
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Retries given callback on false response using exponential backoff.
+     *
+     * @param callable $callback  Callback to retry
+     * @param int $maxRetries     Max retries count
+     * @param int $timeout        Retry interval in milliseconds
+     * @param int $exponent       Exponential multiplier
+     * @return mixed
+     */
+    public function retryOnFalse(
+        callable $callback,
+        int $maxRetries = 3,
+        int $timeout = 1000,
+        int $exponent = 2
+    ) {
+        if ($result = $callback()) {
+            return $result;
+        }
+
+        if ($maxRetries > 0) {
+            usleep($timeout);
+
+            return $this->retryOnFalse(
+                $callback,
+                $maxRetries - 1,
+                $timeout * $exponent,
+                $exponent
+            );
+        }
+
+        return false;
+    }
+}

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -1666,7 +1666,7 @@ class ClientTest extends PredisTestCase
         $firstExpectedResponse = $client->executeCommand($readCommand);
         $this->assertSame($firstExpectedResponse, apcu_fetch($cacheKey));
 
-        // 5. Executes override command and send any other read command to get invalidation from server.
+        // 5. Executes override command.
         $client->executeCommand($overrideCommand);
 
         // 6. Retry read command and make sure that new value cached.
@@ -1721,7 +1721,7 @@ class ClientTest extends PredisTestCase
         $firstExpectedResponse = $client->executeCommand($readCommand);
         $this->assertSame($firstExpectedResponse, apcu_fetch($cacheKey));
 
-        // 5. Executes override command and send any other read command to get invalidation from server.
+        // 5. Executes override command.
         $client->executeCommand($overrideCommand);
 
         // 6. Retry read command and make sure that new value cached.
@@ -1777,7 +1777,7 @@ class ClientTest extends PredisTestCase
         $firstExpectedResponse = $client->executeCommand($readCommand);
         $this->assertSame($firstExpectedResponse, apcu_fetch($cacheKey));
 
-        // 5. Executes override command and send any other read command to get invalidation from server.
+        // 5. Executes override command.
         $client->executeCommand($overrideCommand);
 
         // 6. Retry read command and make sure that new value cached.

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -1568,8 +1568,6 @@ class ClientTest extends PredisTestCase
         $this->assertSame('bar', apcu_fetch('GET_foo'));
 
         $this->assertEquals('OK', $client->set('foo', 'baz'));
-        $this->assertNull($client->get('baz'));
-        $this->assertFalse(apcu_exists('GET_foo'));
 
         $this->assertSame('baz', $client->get('foo'));
         $this->assertSame('baz', apcu_fetch('GET_foo'));
@@ -1595,8 +1593,6 @@ class ClientTest extends PredisTestCase
         $this->assertSame('bar', apcu_fetch('GET_foo'));
 
         $this->assertEquals('OK', $client->set('foo', 'baz'));
-        $this->assertNull($client->get('baz'));
-        $this->assertFalse(apcu_exists('GET_foo'));
 
         $this->assertSame('baz', $client->get('foo'));
         $this->assertSame('baz', apcu_fetch('GET_foo'));
@@ -1619,8 +1615,6 @@ class ClientTest extends PredisTestCase
         $this->assertSame('bar', apcu_fetch('GET_foo'));
 
         $this->assertEquals('OK', $client->set('foo', 'baz'));
-        $this->assertNull($client->get('non_existing_key'));
-        $this->assertFalse(apcu_exists('GET_foo'));
 
         $this->assertSame('baz', $client->get('foo'));
         $this->assertSame('baz', apcu_fetch('GET_foo'));
@@ -1674,7 +1668,6 @@ class ClientTest extends PredisTestCase
 
         // 5. Executes override command and send any other read command to get invalidation from server.
         $client->executeCommand($overrideCommand);
-        $this->assertNull($client->get('non_existing_key'));
 
         // 6. Retry read command and make sure that new value cached.
         // Also check that previous response is different from new one
@@ -1730,7 +1723,6 @@ class ClientTest extends PredisTestCase
 
         // 5. Executes override command and send any other read command to get invalidation from server.
         $client->executeCommand($overrideCommand);
-        $this->assertNull($client->get('non_existing_key'));
 
         // 6. Retry read command and make sure that new value cached.
         // Also check that previous response is different from new one
@@ -1787,7 +1779,6 @@ class ClientTest extends PredisTestCase
 
         // 5. Executes override command and send any other read command to get invalidation from server.
         $client->executeCommand($overrideCommand);
-        $this->assertNull($client->get('non_existing_key'));
 
         // 6. Retry read command and make sure that new value cached.
         // Also check that previous response is different from new one

--- a/tests/Predis/Configuration/Option/ReplicationTest.php
+++ b/tests/Predis/Configuration/Option/ReplicationTest.php
@@ -49,14 +49,16 @@ class ReplicationTest extends PredisTestCase
         /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('__get')
             ->withConsecutive(
+                ['readTimeout'],
                 ['autodiscovery'],
                 ['connections'],
                 ['cache']
             )
             ->willReturnOnConsecutiveCalls(
+                2000,
                 true,
                 $connectionFactory,
                 false
@@ -322,16 +324,18 @@ class ReplicationTest extends PredisTestCase
         /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('__get')
             ->withConsecutive(
                 ['service'],
                 ['connections'],
+                ['readTimeout'],
                 ['cache']
             )
             ->willReturnOnConsecutiveCalls(
                 'mymaster',
                 $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock(),
+                2000,
                 false
             );
 

--- a/tests/Predis/Connection/Cluster/PredisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/PredisClusterTest.php
@@ -518,22 +518,22 @@ class PredisClusterTest extends PredisTestCase
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
 
         $connection1
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection2
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection3
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, false, true);
 
         $connection3
             ->expects($this->once())

--- a/tests/Predis/Connection/Cluster/PredisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/PredisClusterTest.php
@@ -471,4 +471,82 @@ class PredisClusterTest extends PredisTestCase
 
         $this->assertEquals(['response1', 'response2', 'response3'], $cluster->executeCommandOnEachNode($mockCommand));
     }
+
+    /**
+     * @group disconnected
+     */
+    public function testHasDataToRead(): void
+    {
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $cluster = new PredisCluster(new Parameters());
+
+        $cluster->add($connection1);
+        $cluster->add($connection2);
+        $cluster->add($connection3);
+
+        $this->assertTrue($cluster->hasDataToRead());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testRead(): void
+    {
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $connection3
+            ->expects($this->once())
+            ->method('read')
+            ->withAnyParameters()
+            ->willReturn('bar');
+
+        $cluster = new PredisCluster(new Parameters());
+
+        $cluster->add($connection1);
+        $cluster->add($connection2);
+        $cluster->add($connection3);
+
+        $this->assertSame('bar', $cluster->read());
+    }
 }

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -1494,4 +1494,86 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertEquals(['response1', 'response2', 'response3'], $cluster->executeCommandOnEachNode($mockCommand));
     }
+
+    /**
+     * @group disconnected
+     */
+    public function testHasDataToRead(): void
+    {
+        $factory = $this->getMockBuilder(FactoryInterface::class)->getMock();
+
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $cluster = new RedisCluster($factory, new Parameters());
+
+        $cluster->add($connection1);
+        $cluster->add($connection2);
+        $cluster->add($connection3);
+
+        $this->assertTrue($cluster->hasDataToRead());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testRead(): void
+    {
+        $factory = $this->getMockBuilder(FactoryInterface::class)->getMock();
+
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $connection3
+            ->expects($this->once())
+            ->method('read')
+            ->withAnyParameters()
+            ->willReturn('bar');
+
+        $cluster = new RedisCluster($factory, new Parameters());
+
+        $cluster->add($connection1);
+        $cluster->add($connection2);
+        $cluster->add($connection3);
+
+        $this->assertSame('bar', $cluster->read());
+    }
 }

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -1545,22 +1545,22 @@ class RedisClusterTest extends PredisTestCase
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
 
         $connection1
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection2
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection3
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, false, true);
 
         $connection3
             ->expects($this->once())

--- a/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
+++ b/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
@@ -1497,22 +1497,22 @@ repl_backlog_histlen:12978
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
 
         $connection1
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection2
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection3
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, false, true);
 
         $connection3
             ->expects($this->once())

--- a/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
+++ b/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
@@ -1451,6 +1451,84 @@ repl_backlog_histlen:12978
         $this->assertSame($connection->getParameters(), $replication->getParameters());
     }
 
+    /**
+     * @group disconnected
+     */
+    public function testHasDataToRead(): void
+    {
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $replication = new MasterSlaveReplication();
+
+        $replication->add($connection1);
+        $replication->add($connection2);
+        $replication->add($connection3);
+
+        $this->assertTrue($replication->hasDataToRead());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testRead(): void
+    {
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $connection3
+            ->expects($this->once())
+            ->method('read')
+            ->withAnyParameters()
+            ->willReturn('bar');
+
+        $replication = new MasterSlaveReplication();
+
+        $replication->add($connection1);
+        $replication->add($connection2);
+        $replication->add($connection3);
+
+        $this->assertSame('bar', $replication->read());
+    }
+
     public function connectionsProvider(): array
     {
         return [

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -1545,6 +1545,86 @@ class SentinelReplicationTest extends PredisTestCase
         $this->assertSame($sentinel->getParameters(), $replication->getParameters());
     }
 
+    /**
+     * @group disconnected
+     */
+    public function testHasDataToRead(): void
+    {
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+        $sentinel = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $replication = $this->getReplicationConnection('srv', [$sentinel]);
+
+        $replication->add($connection1);
+        $replication->add($connection2);
+        $replication->add($connection3);
+
+        $this->assertTrue($replication->hasDataToRead());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testRead(): void
+    {
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:7003');
+        $sentinel = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
+
+        $connection1
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection2
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $connection3
+            ->expects($this->once())
+            ->method('hasDataToRead')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $connection3
+            ->expects($this->once())
+            ->method('read')
+            ->withAnyParameters()
+            ->willReturn('bar');
+
+        $replication = $this->getReplicationConnection('srv', [$sentinel]);
+
+        $replication->add($connection1);
+        $replication->add($connection2);
+        $replication->add($connection3);
+
+        $this->assertSame('bar', $replication->read());
+    }
+
     public function connectionsProvider(): array
     {
         return [

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -1593,22 +1593,22 @@ class SentinelReplicationTest extends PredisTestCase
         $sentinel = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
         $connection1
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection2
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(false, false, false);
 
         $connection3
-            ->expects($this->once())
+            ->expects($this->exactly(3))
             ->method('hasDataToRead')
             ->withAnyParameters()
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, false, true);
 
         $connection3
             ->expects($this->once())

--- a/tests/Predis/Connection/Traits/RetryTest.php
+++ b/tests/Predis/Connection/Traits/RetryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Predis\Connection\Traits;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class RetryTest extends TestCase
+{
+    private $testClass;
+
+    protected function setUp(): void
+    {
+        $this->testClass = new class() {
+            use Retry;
+        };
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testRetryOnFalse(): void
+    {
+        $counter = 0;
+        $maxRetries = 3;
+
+        $callback = function () use (&$counter, $maxRetries) {
+            if ($counter < $maxRetries) {
+                $counter++;
+                return null;
+            }
+
+            return true;
+        };
+
+        $this->assertTrue($this->testClass->retryOnFalse($callback, $maxRetries));
+        $this->assertEquals(3, $counter);
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     * @throws Exception
+     */
+    public function testRetryOnError(): void
+    {
+        $counter = 0;
+        $maxRetries = 3;
+
+        $callback = static function () use (&$counter, $maxRetries) {
+            if ($counter < $maxRetries) {
+                $counter++;
+                throw new Exception();
+            }
+
+            return true;
+        };
+
+        $onCatchCallback = function (Throwable $e) {
+            // Nothing to be executed, just to make sure that all code covered.
+        };
+
+        $this->assertTrue($this->testClass->retryOnError($callback, $onCatchCallback, $maxRetries));
+        $this->assertEquals(3, $counter);
+    }
+}

--- a/tests/Predis/Connection/Traits/RetryTest.php
+++ b/tests/Predis/Connection/Traits/RetryTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Predis\Connection\Traits;
 
 use Exception;
@@ -29,6 +39,7 @@ class RetryTest extends TestCase
         $callback = function () use (&$counter, $maxRetries) {
             if ($counter < $maxRetries) {
                 $counter++;
+
                 return null;
             }
 


### PR DESCRIPTION
This PR enhances CSC process by adding check for pending invalidations from server before actual processing starts.

With this extra step we ensured that even if we hit our cache instead of server, we still keep tracking of invalidations that server sends to us.